### PR TITLE
Fix code scanning alert no. 5: Use of password hash with insufficient computational effort

### DIFF
--- a/webapp-backoffice/package.json
+++ b/webapp-backoffice/package.json
@@ -67,7 +67,8 @@
 		"typescript": "5.2.2",
 		"usehooks-ts": "^2.9.1",
 		"zod": "3.21.1",
-		"zod-prisma-types": "^3.1.8"
+		"zod-prisma-types": "^3.1.8",
+		"bcrypt": "^5.1.1"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.22.15",

--- a/webapp-backoffice/src/server/routers/user.ts
+++ b/webapp-backoffice/src/server/routers/user.ts
@@ -4,7 +4,7 @@ import {
 	UserCreateInputSchema,
 	UserUpdateInputSchema
 } from '@/prisma/generated/zod';
-import crypto from 'crypto';
+import bcrypt from 'bcrypt';
 import { Prisma, PrismaClient, User } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import {
@@ -723,10 +723,8 @@ export const userRouter = router({
 				});
 			}
 
-			const hashedPassword = crypto
-				.createHash('sha256')
-				.update(password)
-				.digest('hex');
+			const salt = bcrypt.genSaltSync(10);
+			const hashedPassword = bcrypt.hashSync(password, salt);
 
 			const updatedUser = await ctx.prisma.user.update({
 				where: {


### PR DESCRIPTION
Fixes [https://github.com/DISIC/jedonnemonavis.numerique.gouv.fr/security/code-scanning/5](https://github.com/DISIC/jedonnemonavis.numerique.gouv.fr/security/code-scanning/5)

To fix the problem, we need to replace the use of the SHA-256 hashing algorithm with a more secure password hashing scheme such as `bcrypt`. This will involve importing the `bcrypt` library, generating a salt, and using `bcrypt` to hash the password. The existing functionality of the code will remain unchanged, but the password hashing process will be significantly more secure.

1. Import the `bcrypt` library.
2. Replace the SHA-256 hashing code with `bcrypt` hashing code.
3. Ensure that the salt is generated and used in the hashing process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
