### PR TITLE
feat: add HTTP security headers

### DIFF
--- a/webapp-backoffice/next.config.js
+++ b/webapp-backoffice/next.config.js
@@ -20,6 +20,21 @@ const nextConfig = {
 	assetPrefix: '/v2',
 	rewrites() {
 		return [{ source: '/v2/_next/:path*', destination: '/_next/:path*' }];
+	},
+	async headers() {
+		return [
+			{
+				source: '/:path*',
+				headers: [
+					{ key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+					{ key: 'X-Content-Type-Options', value: 'nosniff' },
+					{ key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+					{ key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+					{ key: 'X-XSS-Protection', value: '0' },
+					{ key: 'X-Frame-Options', value: 'DENY' },
+				],
+			},
+		];
 	}
 };
 

--- a/webapp-form/next.config.js
+++ b/webapp-form/next.config.js
@@ -39,6 +39,16 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          { key: "X-XSS-Protection", value: "0" },
+        ],
+      },
     ];
   },
   i18n,


### PR DESCRIPTION
## Summary

Active 5 en-têtes HTTP de sécurité côté response sur les deux apps (`webapp-backoffice` et `webapp-form`) via `next.config.js` :

- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` — force HTTPS pour 2 ans, sous-domaines compris.
- `X-Content-Type-Options: nosniff` — empêche le MIME sniffing.
- `Referrer-Policy: strict-origin-when-cross-origin` — limite l'envoi du Referer cross-origin.
- `Permissions-Policy: camera=(), microphone=(), geolocation=()` — désactive les API navigateur non utilisées.
- `X-XSS-Protection: 0` — désactive le filtre XSS legacy (recommandation moderne).

`webapp-backoffice` ajoute en plus `X-Frame-Options: DENY` ; `webapp-form` ne le met pas, ce qui reste compatible avec l'embedding iframe via le widget `jdma-modal-widget.js`.

## Test plan

- [x] Vérifier sur staging que les headers sont bien renvoyés (`curl -I` sur une page des deux apps).
- [x] Vérifier que le widget iframe sur un site tiers continue de charger `webapp-form`.
- [x] CI verte (build sur Node 22.x + 24.x).