### PR TITLE
fix: surface rate-limit error on dynamic form (avis/[id])

### DIFF
--- a/webapp-form/src/pages/avis/[id].tsx
+++ b/webapp-form/src/pages/avis/[id].tsx
@@ -11,6 +11,7 @@ import Success from '@codegouvfr/react-dsfr/picto/Success';
 import { trpc } from '@/src/utils/trpc';
 import { v4 as uuidv4 } from 'uuid';
 import Notice from '@codegouvfr/react-dsfr/Notice';
+import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import {
 	DynamicAnswerData,
 	FormAnswers,
@@ -41,6 +42,7 @@ export default function AvisPage({
 	const [currentStepIndex, setCurrentStepIndex] = useState(0);
 	const [answers, setAnswers] = useState<FormAnswers>({});
 	const [isSubmitted, setIsSubmitted] = useState(false);
+	const [isRateLimitReached, setIsRateLimitReached] = useState(false);
 	const [reviewId, setReviewId] = useState<{
 		id: number;
 		created_at: Date;
@@ -82,12 +84,17 @@ export default function AvisPage({
 
 	const createReview = trpc.review.dynamicCreate.useMutation({
 		onSuccess: data => {
+			setIsRateLimitReached(false);
 			setReviewId({
 				id: data.data.id,
 				created_at: data.data.created_at,
 			});
 		},
 		onError: error => {
+			if (error.data?.httpStatus === 429) {
+				localStorage.removeItem('userId');
+				setIsRateLimitReached(true);
+			}
 			console.error('Error creating review:', error);
 		},
 	});
@@ -187,7 +194,7 @@ export default function AvisPage({
 		/>
 	);
 
-	if (isSubmitted) {
+	if (isSubmitted && !isRateLimitReached) {
 		return (
 			<div ref={contentRef}>
 				{isPreview && !isWidget && <PreviewAlert />}
@@ -258,6 +265,18 @@ export default function AvisPage({
 									isWidget={isWidget}
 								/>
 
+								{isRateLimitReached && (
+									<div role="alert" className={fr.cx('fr-mt-4v')}>
+										<Alert
+											closable
+											onClose={() => setIsRateLimitReached(false)}
+											severity="error"
+											title=""
+											description="Trop de tentatives de dépôt d'avis, veuillez patienter 1h avant de pouvoir re-déposer."
+										/>
+									</div>
+								)}
+
 								<div
 									className={classes.buttonsContainer}
 									style={{
@@ -270,7 +289,7 @@ export default function AvisPage({
 											priority="primary"
 											iconId="fr-icon-arrow-right-line"
 											iconPosition="right"
-											disabled={isFirstAnswerEmpty}
+											disabled={isFirstAnswerEmpty || isRateLimitReached}
 											type="submit"
 										>
 											Continuer
@@ -279,7 +298,7 @@ export default function AvisPage({
 										<Button
 											priority="primary"
 											type="submit"
-											disabled={!hasAllRequiredAnswers}
+											disabled={!hasAllRequiredAnswers || isRateLimitReached}
 										>
 											Envoyer mon avis
 										</Button>


### PR DESCRIPTION
## Contexte

Sur `webapp-form/src/pages/avis/[id].tsx` (formulaire dynamique), quand l'utilisateur dépasse le rate-limit, la mutation `review.dynamicCreate` retourne 429 mais l'`onError` se contentait d'un `console.error`. Conséquences :

- Aucun feedback visible côté utilisateur.
- `reviewId` n'est jamais défini, donc à chaque étape suivante on retombe dans la branche `createReview.mutate(...)` qui ré-échoue silencieusement.
- L'utilisateur remplit le formulaire jusqu'au bout, voit l'écran « Merci », mais **rien n'est persisté en base** (shadow ban).

Comportement très différent de `webapp-form/src/pages/[id].tsx` (formulaire statique) où le 429 est déjà bien intercepté et affiché via `FormFirstBlock`.

## Correction

Aligne le comportement sur le statique (Option B — maquette déjà validée par le designer) :

- Nouveau state `isRateLimitReached` (init `false`).
- `dynamicCreate.onError` détecte `httpStatus === 429`, vide `localStorage.userId` et passe `isRateLimitReached` à `true`. (`dynamicInsertOrUpdate` est un `publicProcedure` non rate-limité, donc inchangé — même découpage que le statique.)
- `dynamicCreate.onSuccess` remet `isRateLimitReached` à `false` (cas où l'utilisateur clôt l'alerte puis retente avec succès).
- Affichage d'un `Alert` DSFR `severity="error"` au-dessus du conteneur de boutons, avec le message exact utilisé dans `FormFirstBlock` :
  > Trop de tentatives de dépôt d'avis, veuillez patienter 1h avant de pouvoir re-déposer.
- Désactivation des boutons « Continuer » et « Envoyer mon avis » quand `isRateLimitReached`.
- Garde supplémentaire : l'écran « Merci » n'est plus affiché si `isRateLimitReached` est vrai (filet de sécurité au cas où le 429 arriverait après `setIsSubmitted(true)`).

## Test plan

- [ ] Forcer un 429 (rate-limit configuré court, ou bypass via `LIMITER_ALLOWED_IPS`) sur un formulaire dynamique : vérifier que l'`Alert` apparaît et que les boutons sont désactivés.
- [ ] Vérifier que `localStorage.userId` est bien vidé à la 429.
- [ ] Fermer l'alerte → on peut continuer à interagir avec le formulaire mais pas soumettre tant que la fenêtre n'est pas réinitialisée.
- [ ] Vérifier que le formulaire statique (`/[id]`) n'est pas régressé.
- [ ] Vérifier en mode `widget` (postMessage parent inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)