### PR TITLE
fix(keywords): repair recurring-keyword filter and add phrase subsumption

### DIFF
--- a/webapp-backoffice/src/server/routers/answer/get-keywords.ts
+++ b/webapp-backoffice/src/server/routers/answer/get-keywords.ts
@@ -20,6 +20,12 @@ export const getKeywordsInputSchema = z.object({
 	size: z.number().optional().default(10)
 });
 
+const CANDIDATE_POOL_SIZE = 200;
+const MIN_OCCURRENCES = 5;
+const SUBSUMPTION_RATIO = 0.7;
+
+type KeywordBucket = { key: string; count: number };
+
 export const getKeywordsQuery = async ({
 	ctx,
 	input
@@ -79,40 +85,75 @@ export const getKeywordsQuery = async ({
 		index: 'jdma-answers-tokens',
 		query: {
 			bool: {
-				must: mustClauses,
-				must_not: [
-					{
-						wildcard: {
-							answer_tokens: '*_*'
-						}
-					}
-				]
+				must: mustClauses
 			}
 		},
 		aggs: {
-			keywords: {
+			unigrams: {
 				terms: {
 					field: 'answer_tokens',
-					size: size + excludeKeywords.length
+					include: '[^ _]+',
+					min_doc_count: MIN_OCCURRENCES,
+					size: CANDIDATE_POOL_SIZE
+				}
+			},
+			bigrams: {
+				terms: {
+					field: 'answer_tokens',
+					include: '[^ _]+ [^ _]+',
+					min_doc_count: MIN_OCCURRENCES,
+					size: CANDIDATE_POOL_SIZE
 				}
 			}
 		},
 		size: 0
 	});
 
-	const buckets = (keywordsAggs?.aggregations?.keywords as any)?.buckets ?? [];
-
-	const data = buckets
-		.filter(
-			(bucket: any) =>
-				bucket.doc_count >= 5 &&
-				!excludeKeywords.includes(bucket.key.toLowerCase())
-		)
-		.slice(0, size)
-		.map((bucket: any) => ({
-			keyword: bucket.key,
-			count: bucket.doc_count
+	const toBuckets = (agg: any): KeywordBucket[] =>
+		((agg?.buckets as any[]) ?? []).map(bucket => ({
+			key: bucket.key as string,
+			count: bucket.doc_count as number
 		}));
 
-	return { data: data as { keyword: string; count: number }[] };
+	const unigrams = toBuckets(keywordsAggs?.aggregations?.unigrams).filter(
+		unigram => !excludeKeywords.includes(unigram.key.toLowerCase())
+	);
+
+	const bigrams = toBuckets(keywordsAggs?.aggregations?.bigrams).filter(
+		bigram =>
+			!bigram.key
+				.split(' ')
+				.every(word => excludeKeywords.includes(word.toLowerCase()))
+	);
+
+	const suppressedUnigrams = new Set<string>();
+	const subsumingBigrams = new Map<string, KeywordBucket>();
+
+	unigrams.forEach(unigram => {
+		const dominantBigram = bigrams
+			.filter(bigram => bigram.key.split(' ').includes(unigram.key))
+			.reduce<KeywordBucket | null>(
+				(max, bigram) =>
+					!max || bigram.count > max.count ? bigram : max,
+				null
+			);
+
+		if (
+			dominantBigram &&
+			dominantBigram.count >= unigram.count * SUBSUMPTION_RATIO
+		) {
+			suppressedUnigrams.add(unigram.key);
+			subsumingBigrams.set(dominantBigram.key, dominantBigram);
+		}
+	});
+
+	const data = [
+		...unigrams.filter(unigram => !suppressedUnigrams.has(unigram.key)),
+		...subsumingBigrams.values()
+	]
+		.sort((a, b) => b.count - a.count)
+		.slice(0, size)
+		.map(({ key, count }) => ({ keyword: key, count }));
+
+	return { data };
 };

--- a/webapp-backoffice/src/utils/keywords.ts
+++ b/webapp-backoffice/src/utils/keywords.ts
@@ -5,5 +5,21 @@ export const excludeKeywords = [
 	'bonjour',
 	'tres',
 	'ras',
-	'beaucoup'
+	'beaucoup',
+	'plus',
+	'fait',
+	'faire',
+	'ete',
+	'avoir',
+	'faut',
+	'cela',
+	'donc',
+	'comme',
+	'quand',
+	'mais',
+	'car',
+	'alors',
+	'aussi',
+	"qu'il",
+	"m'a"
 ];


### PR DESCRIPTION
## Problem

The **recurring-keyword filter** on the form Reviews tab returned nothing even on forms with hundreds of matching reviews.

Root cause: the aggregation in \`get-keywords.ts\` applied a **document-level** \`must_not\` wildcard \`*_*\` on \`answer_tokens\`. The \`keywords_analyzer\` is a shingle analyzer whose stopword filter emits a filler token \`_\` (e.g. \`_ demande\`, \`demande _\`). Almost every real verbatim therefore contains at least one \`_\` token, so the \`must_not\` excluded nearly **all** documents — verified live: the same filters matched 437 reviews without the clause and only 10 with it. With so few docs, no word reached the 5-occurrence threshold → empty result.

## Changes

- **Remove** the document-killing \`must_not '*_*'\`.
- **Two targeted \`terms\` aggregations** on \`answer_tokens\`:
  - unigrams (\`include: "[^ _]+"\`)
  - content bigrams (\`include: "[^ _]+ [^ _]+"\`)
  - the \`include\` regexes drop filler shingles for free; the \`>= 5\` threshold is applied via \`min_doc_count\`.
- **Phrase subsumption** (avoids \`très\` / \`bien\` / \`très bien\` repetition): a unigram is hidden only when a single bigram covers **≥ 70%** of its occurrences (max single bigram, no double-counting). High-frequency standalone words (e.g. \`retraite\`, \`demande\`) are protected because a narrow phrase never reaches 70% of their count.
- **Stopword list** extended with grammatical glue only (kept meaningful nouns). Applied to unigrams only — bigrams stay eligible, so \`très bien\` survives even though \`très\` is a stopword.

UI wording is unchanged. Chips display the normalized (lowercased, de-accented) token; click-through still matches the original text because the reviews search is accent-insensitive.

## Notes / out of scope

- Long-term, the stopword handling and accent-preserving display belong in the indexing pipeline (a \`_french_\` stop filter + reindex, and storing the surface form). That pipeline is not in this repo.

## Test plan

- [ ] On a form with verbatims, open Reviews → recurring keywords now populate.
- [ ] Combine filters (e.g. comprehension) → keywords reflect the filtered subset.
- [ ] Click a keyword → reviews filter by it.