### PR TITLE
feat(open-api): GET /api/open-api/reviews partner endpoint

### DIFF
--- a/webapp-backoffice/cypress.config.ts
+++ b/webapp-backoffice/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress';
+import { dbTasks } from './cypress/plugins/db-tasks';
 
 export default defineConfig({
 	e2e: {
@@ -28,7 +29,8 @@ export default defineConfig({
 					console.table(message);
 
 					return null;
-				}
+				},
+				...dbTasks
 			});
 		},
 

--- a/webapp-backoffice/cypress/e2e/jdma/api/reviews-list.cy.ts
+++ b/webapp-backoffice/cypress/e2e/jdma/api/reviews-list.cy.ts
@@ -1,0 +1,293 @@
+type Ctx = {
+	entity_id: number;
+	product_ids: number[];
+	form_id: number;
+	button_id: number;
+	api_key: string;
+	api_key_id: number;
+	user_id: number;
+};
+
+const ANCHOR = '2026-01-15T12:00:00.000Z';
+
+const makeReview = (ctx: Ctx, dayOffset: number, slug: 'root' | 'bug') => ({
+	form_id: ctx.form_id,
+	product_id: ctx.product_ids[0],
+	button_id: ctx.button_id,
+	created_at: new Date(
+		Date.parse(ANCHOR) + dayOffset * 86_400_000
+	).toISOString(),
+	answers:
+		slug === 'bug'
+			? [
+					{
+						field_code: 'bug_kind',
+						field_label: 'Type de retour',
+						answer_text: 'BUG',
+						answer_item_id: 1,
+						kind: 'radio' as const
+					},
+					{
+						field_code: 'verbatim',
+						field_label: 'Pouvez-vous nous en dire plus ?',
+						answer_text: `Bug ${dayOffset}`,
+						kind: 'text' as const
+					}
+			  ]
+			: [
+					{
+						field_code: 'satisfaction',
+						field_label: 'Satisfaction',
+						answer_text: 'good',
+						answer_item_id: 4,
+						intention: 'good' as const,
+						kind: 'radio' as const
+					}
+			  ]
+});
+
+const apiRequest = (
+	apiKey: string | null,
+	qs: Record<string, string | number>
+) =>
+	cy.request({
+		method: 'GET',
+		url: '/api/open-api/reviews',
+		qs,
+		headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+		failOnStatusCode: false
+	});
+
+describe('OpenAPI GET /reviews', () => {
+	it('documents the endpoint in the OpenAPI spec', () => {
+		cy.request('/api/open-api').then(res => {
+			expect(res.status).to.eq(200);
+			expect(res.body.paths).to.have.property('/reviews');
+			expect(res.body.paths['/reviews']).to.have.property('get');
+		});
+	});
+
+	it('refuses requests without API key', () => {
+		apiRequest(null, { form_id: 1 }).its('status').should('eq', 401);
+	});
+
+	it('refuses unknown API key', () => {
+		apiRequest('definitely-not-a-key', { form_id: 1 })
+			.its('status')
+			.should('eq', 401);
+	});
+
+	describe('happy path on form bug', () => {
+		let ctx: Ctx;
+
+		before(() => {
+			cy.task<Ctx>('db:setupApiCtx', {
+				template_slug: 'bug',
+				api_scope: 'product'
+			}).then(c => {
+				ctx = c;
+				cy.task('db:seedReviews', [
+					makeReview(ctx, 0, 'bug'),
+					makeReview(ctx, -1, 'bug'),
+					makeReview(ctx, -2, 'bug')
+				]);
+			});
+		});
+
+		after(() => cy.task('db:cleanupApiCtx', ctx));
+
+		it('returns the seeded reviews with form_template_slug=bug', () => {
+			apiRequest(ctx.api_key, { form_id: ctx.form_id }).then(res => {
+				expect(res.status).to.eq(200);
+				expect(res.body.data).to.have.length(3);
+				res.body.data.forEach((r: any) => {
+					expect(r.form_template_slug).to.eq('bug');
+					expect(r.product_id).to.eq(ctx.product_ids[0]);
+					expect(r.answers).to.exist;
+					expect(r.answers.length).to.be.greaterThan(0);
+				});
+				expect(res.body.metadata.has_more).to.eq(false);
+				expect(res.body.metadata.next_cursor).to.eq(null);
+			});
+		});
+
+		it('omits answers when include_answers=false', () => {
+			apiRequest(ctx.api_key, {
+				form_id: ctx.form_id,
+				include_answers: 'false'
+			}).then(res => {
+				expect(res.status).to.eq(200);
+				res.body.data.forEach((r: any) => expect(r.answers).to.eq(undefined));
+			});
+		});
+	});
+
+	describe('pagination cursor', () => {
+		let ctx: Ctx;
+
+		before(() => {
+			cy.task<Ctx>('db:setupApiCtx', {
+				template_slug: 'bug',
+				api_scope: 'product'
+			}).then(c => {
+				ctx = c;
+				const reviews = Array.from({ length: 7 }, (_, i) =>
+					makeReview(ctx, -i, 'bug')
+				);
+				cy.task('db:seedReviews', reviews);
+			});
+		});
+
+		after(() => cy.task('db:cleanupApiCtx', ctx));
+
+		it('paginates with stable order and exposes next_cursor', () => {
+			const collected: number[] = [];
+			apiRequest(ctx.api_key, { form_id: ctx.form_id, limit: 3 }).then(p1 => {
+				expect(p1.status).to.eq(200);
+				expect(p1.body.data).to.have.length(3);
+				expect(p1.body.metadata.has_more).to.eq(true);
+				collected.push(...p1.body.data.map((r: any) => r.id));
+
+				apiRequest(ctx.api_key, {
+					form_id: ctx.form_id,
+					limit: 3,
+					cursor: p1.body.metadata.next_cursor
+				}).then(p2 => {
+					expect(p2.status).to.eq(200);
+					expect(p2.body.data).to.have.length(3);
+					collected.push(...p2.body.data.map((r: any) => r.id));
+
+					apiRequest(ctx.api_key, {
+						form_id: ctx.form_id,
+						limit: 3,
+						cursor: p2.body.metadata.next_cursor
+					}).then(p3 => {
+						expect(p3.status).to.eq(200);
+						expect(p3.body.data).to.have.length(1);
+						expect(p3.body.metadata.has_more).to.eq(false);
+						expect(p3.body.metadata.next_cursor).to.eq(null);
+						collected.push(...p3.body.data.map((r: any) => r.id));
+
+						expect(new Set(collected).size).to.eq(7);
+					});
+				});
+			});
+		});
+
+		it('rejects malformed cursor with 400', () => {
+			apiRequest(ctx.api_key, {
+				form_id: ctx.form_id,
+				cursor: 'not-base64-json'
+			})
+				.its('status')
+				.should('eq', 400);
+		});
+
+		it('forged cursor cannot bypass start_date filter', () => {
+			const future = '2099-01-01';
+			const raw = JSON.stringify({
+				ts: '2000-01-01T00:00:00.000Z',
+				id: 99999
+			});
+			const forged = btoa(raw)
+				.replace(/\+/g, '-')
+				.replace(/\//g, '_')
+				.replace(/=+$/, '');
+			apiRequest(ctx.api_key, {
+				form_id: ctx.form_id,
+				start_date: future,
+				end_date: future,
+				cursor: forged
+			}).then(res => {
+				expect(res.status).to.eq(200);
+				expect(res.body.data).to.have.length(0);
+			});
+		});
+	});
+
+	describe('access control', () => {
+		let owner: Ctx;
+		let intruder: Ctx;
+
+		before(() => {
+			cy.task<Ctx>('db:setupApiCtx', {
+				template_slug: 'root',
+				api_scope: 'product'
+			}).then(c => (owner = c));
+			cy.task<Ctx>('db:setupApiCtx', {
+				template_slug: 'root',
+				api_scope: 'product'
+			}).then(c => (intruder = c));
+		});
+
+		after(() => {
+			cy.task('db:cleanupApiCtx', owner);
+			cy.task('db:cleanupApiCtx', intruder);
+		});
+
+		it('returns 404 (anti-enumeration) when accessing another tenant form', () => {
+			apiRequest(intruder.api_key, { form_id: owner.form_id })
+				.its('status')
+				.should('eq', 404);
+		});
+
+		it('returns 404 on unknown form id', () => {
+			apiRequest(owner.api_key, { form_id: 999_999_999 })
+				.its('status')
+				.should('eq', 404);
+		});
+
+		it('blocks legacy form ids 1/2 for non admins', () => {
+			apiRequest(owner.api_key, { form_id: 1 }).its('status').should('eq', 404);
+			apiRequest(owner.api_key, { form_id: 2 }).its('status').should('eq', 404);
+		});
+
+		it('rejects incoherent product_id', () => {
+			apiRequest(owner.api_key, {
+				form_id: owner.form_id,
+				product_id: owner.product_ids[0] + 999_999
+			})
+				.its('status')
+				.should('eq', 400);
+		});
+	});
+
+	describe('input validation', () => {
+		let ctx: Ctx;
+		before(() =>
+			cy
+				.task<Ctx>('db:setupApiCtx', {
+					template_slug: 'bug',
+					api_scope: 'product'
+				})
+				.then(c => (ctx = c))
+		);
+		after(() => cy.task('db:cleanupApiCtx', ctx));
+
+		it('rejects malformed date', () => {
+			apiRequest(ctx.api_key, {
+				form_id: ctx.form_id,
+				start_date: '2026-13-40'
+			})
+				.its('status')
+				.should('eq', 400);
+		});
+
+		it('rejects inverted date range', () => {
+			apiRequest(ctx.api_key, {
+				form_id: ctx.form_id,
+				start_date: '2026-12-31',
+				end_date: '2026-01-01'
+			})
+				.its('status')
+				.should('eq', 400);
+		});
+
+		it('rejects deleted form with 404', () => {
+			cy.task('db:markFormDeleted', ctx.form_id);
+			apiRequest(ctx.api_key, { form_id: ctx.form_id })
+				.its('status')
+				.should('eq', 404);
+		});
+	});
+});

--- a/webapp-backoffice/cypress/e2e/jdma/launcher.cy.ts
+++ b/webapp-backoffice/cypress/e2e/jdma/launcher.cy.ts
@@ -8,3 +8,4 @@ import './bo/reviewCheck.cy.ts';
 import './bo/account.cy.ts';
 import './bo/users.cy.ts';
 import './bo/logs.cy.ts';
+import './api/reviews-list.cy.ts';

--- a/webapp-backoffice/cypress/plugins/db-tasks.ts
+++ b/webapp-backoffice/cypress/plugins/db-tasks.ts
@@ -1,0 +1,180 @@
+import { PrismaClient } from '@prisma/client';
+import crypto from 'crypto';
+
+const prisma = new PrismaClient();
+
+type SeedReviewArg = {
+	form_id: number;
+	product_id: number;
+	button_id: number;
+	created_at: string;
+	answers?: Array<{
+		field_code: string;
+		field_label: string;
+		answer_text: string;
+		answer_item_id?: number;
+		intention?:
+			| 'very_good'
+			| 'good'
+			| 'medium'
+			| 'bad'
+			| 'very_bad'
+			| 'neutral'
+			| null;
+		kind?: 'text' | 'checkbox' | 'radio';
+		parent_field_code?: string;
+	}>;
+};
+
+type SetupCtxArg = {
+	template_slug: 'root' | 'bug';
+	api_scope?: 'admin' | 'product' | 'entity' | 'none';
+	entity_products?: number;
+};
+
+type Ctx = {
+	entity_id: number;
+	product_ids: number[];
+	form_id: number;
+	button_id: number;
+	api_key: string;
+	api_key_id: number;
+	user_id: number;
+};
+
+export const dbTasks = {
+	'db:setupApiCtx': async (arg: SetupCtxArg): Promise<Ctx> => {
+		const suffix = crypto.randomBytes(4).toString('hex');
+		const tpl = await prisma.formTemplate.findUniqueOrThrow({
+			where: { slug: arg.template_slug }
+		});
+		const user = await prisma.user.create({
+			data: {
+				email: `api-test-${suffix}@example.org`,
+				firstName: 'Api',
+				lastName: 'Test',
+				password: 'unused',
+				role: 'user',
+				active: true
+			}
+		});
+		const entity = await prisma.entity.create({
+			data: { name: `E-${suffix}`, acronym: `E${suffix}` }
+		});
+		const productCount = Math.max(1, arg.entity_products ?? 1);
+		const products = await Promise.all(
+			Array.from({ length: productCount }, (_, i) =>
+				prisma.product.create({
+					data: {
+						title: `P-${suffix}-${i}`,
+						entity_id: entity.id,
+						isPublic: true
+					}
+				})
+			)
+		);
+		const form = await prisma.form.create({
+			data: {
+				title: `F-${suffix}`,
+				form_template_id: tpl.id,
+				product_id: products[0].id,
+				user_id: user.id
+			}
+		});
+		const button = await prisma.button.create({
+			data: {
+				title: `B-${suffix}`,
+				form_id: form.id,
+				isTest: false
+			}
+		});
+
+		const apiKey = `test-${suffix}-${crypto.randomBytes(12).toString('hex')}`;
+		const scope = arg.api_scope ?? 'product';
+		const created = await prisma.apiKey.create({
+			data: {
+				key: apiKey,
+				scope: scope === 'admin' ? 'admin' : 'user',
+				user_id: user.id,
+				product_id: scope === 'product' ? products[0].id : null,
+				entity_id: scope === 'entity' ? entity.id : null
+			}
+		});
+
+		return {
+			entity_id: entity.id,
+			product_ids: products.map(p => p.id),
+			form_id: form.id,
+			button_id: button.id,
+			api_key: apiKey,
+			api_key_id: created.id,
+			user_id: user.id
+		};
+	},
+
+	'db:seedReviews': async (
+		args: SeedReviewArg[]
+	): Promise<Array<{ id: number; created_at: string }>> => {
+		const out: Array<{ id: number; created_at: string }> = [];
+		for (const a of args) {
+			const review = await prisma.review.create({
+				data: {
+					form_id: a.form_id,
+					product_id: a.product_id,
+					button_id: a.button_id,
+					created_at: new Date(a.created_at),
+					has_verbatim: (a.answers ?? []).some(
+						ans => ans.field_code === 'verbatim'
+					)
+				}
+			});
+			const parentMap = new Map<string, number>();
+			for (const ans of a.answers ?? []) {
+				const created = await prisma.answer.create({
+					data: {
+						review_id: review.id,
+						review_created_at: review.created_at,
+						created_at: review.created_at,
+						field_code: ans.field_code,
+						field_label: ans.field_label,
+						answer_text: ans.answer_text,
+						answer_item_id: ans.answer_item_id ?? 0,
+						kind: ans.kind ?? 'text',
+						intention: ans.intention ?? null,
+						parent_answer_id: ans.parent_field_code
+							? parentMap.get(ans.parent_field_code) ?? null
+							: null
+					}
+				});
+				parentMap.set(ans.field_code, created.id);
+			}
+			out.push({ id: review.id, created_at: review.created_at.toISOString() });
+		}
+		return out;
+	},
+
+	'db:cleanupApiCtx': async (ctx: Ctx): Promise<null> => {
+		await prisma.apiKeyLog.deleteMany({ where: { apikey_id: ctx.api_key_id } });
+		await prisma.apiKey.deleteMany({ where: { id: ctx.api_key_id } });
+		await prisma.answer.deleteMany({
+			where: { review: { product_id: { in: ctx.product_ids } } }
+		});
+		await prisma.review.deleteMany({
+			where: { product_id: { in: ctx.product_ids } }
+		});
+		await prisma.button.deleteMany({ where: { id: ctx.button_id } });
+		await prisma.form.deleteMany({ where: { id: ctx.form_id } });
+		await prisma.product.deleteMany({ where: { id: { in: ctx.product_ids } } });
+		await prisma.entity.deleteMany({ where: { id: ctx.entity_id } });
+		await prisma.user.deleteMany({ where: { id: ctx.user_id } });
+		return null;
+	},
+
+	'db:markFormDeleted': async (form_id: number): Promise<null> => {
+		await prisma.form.update({
+			where: { id: form_id },
+			data: { deleted_at: new Date(), isDeleted: true }
+		});
+		return null;
+	}
+};

--- a/webapp-backoffice/prisma/migrations/20260616120000_add_review_form_id_index/migration.sql
+++ b/webapp-backoffice/prisma/migrations/20260616120000_add_review_form_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Review_form_id_created_at_id_idx" ON "Review"("form_id", "created_at", "id");

--- a/webapp-backoffice/prisma/schema.prisma
+++ b/webapp-backoffice/prisma/schema.prisma
@@ -450,6 +450,7 @@ model Review {
   @@id([id, created_at])
   @@index([product_id, created_at])
   @@index([product_id, created_at, button_id])
+  @@index([form_id, created_at, id])
 }
 
 model ReviewViewLog {

--- a/webapp-backoffice/src/server/routers/open-api/index.ts
+++ b/webapp-backoffice/src/server/routers/open-api/index.ts
@@ -30,6 +30,12 @@ import {
 	triggerSendNotifMailsOutputSchema
 } from './trigger-send-notif-mails';
 
+import {
+	reviewsListQuery,
+	reviewsListInputSchema,
+	reviewsListOutputSchema
+} from './reviews-list';
+
 const openAPIRouter = router({
 	health: publicProcedure
 		.meta({
@@ -114,7 +120,28 @@ const openAPIRouter = router({
 		})
 		.input(triggerSendNotifMailsInputSchema)
 		.output(triggerSendNotifMailsOutputSchema)
-		.mutation(triggerSendNotifMailsMutation)
+		.mutation(triggerSendNotifMailsMutation),
+
+	reviewsList: protectedApiProcedure
+		.meta({
+			openapi: {
+				method: 'GET',
+				path: '/reviews',
+				protect: true,
+				enabled: true,
+				summary:
+					"Liste paginée des avis bruts pour un formulaire donné (avis classiques et remontées d'information).",
+				example: {
+					request: {
+						form_id: 1,
+						limit: 50
+					}
+				}
+			}
+		})
+		.input(reviewsListInputSchema)
+		.output(reviewsListOutputSchema)
+		.query(reviewsListQuery)
 });
 
 export default openAPIRouter;

--- a/webapp-backoffice/src/server/routers/open-api/info-services.ts
+++ b/webapp-backoffice/src/server/routers/open-api/info-services.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { Context } from '@/src/server/trpc';
+import { getAuthorizedProductIds } from './utils';
 
 export const infoServicesQuery = async ({
 	ctx
@@ -7,26 +8,7 @@ export const infoServicesQuery = async ({
 	ctx: Context;
 	input: {};
 }) => {
-	const getAuthorizedProductIds = async (): Promise<number[]> => {
-		if (ctx.api_key?.product_id) {
-			return [ctx.api_key.product_id];
-		}
-
-		if (ctx.api_key?.entity_id) {
-			const entity = await ctx.prisma.entity.findFirst({
-				where: { id: ctx.api_key.entity_id },
-				include: { products: true }
-			});
-
-			if (entity && entity.products) {
-				return entity.products.map(prod => prod.id);
-			}
-		}
-
-		return [];
-	};
-
-	const authorized_products_ids: number[] = await getAuthorizedProductIds();
+	const authorized_products_ids: number[] = await getAuthorizedProductIds(ctx);
 
 	const products = await ctx.prisma.product.findMany({
 		where: {

--- a/webapp-backoffice/src/server/routers/open-api/reviews-list.ts
+++ b/webapp-backoffice/src/server/routers/open-api/reviews-list.ts
@@ -1,0 +1,253 @@
+import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@prisma/client';
+import { z } from 'zod';
+import type { Context } from '@/src/server/trpc';
+import { getDateWhereFromUTCRange, isValidDate } from '@/src/utils/tools';
+import {
+	LEGACY_FORM_IDS,
+	decodeCursor,
+	encodeCursor,
+	getAuthorizedProductIds
+} from './utils';
+
+const dateString = z
+	.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/, 'Date au format YYYY-MM-DD attendue')
+	.refine(isValidDate, 'Date invalide');
+
+export const reviewsListInputSchema = z
+	.object({
+		form_id: z.number().int().positive(),
+		product_id: z.number().int().positive().optional(),
+		start_date: dateString.optional(),
+		end_date: dateString.optional(),
+		cursor: z.string().optional(),
+		limit: z.number().int().min(1).max(100).default(50),
+		include_answers: z
+			.preprocess(
+				v => (v === 'false' ? false : v === 'true' ? true : v),
+				z.boolean()
+			)
+			.default(true)
+	})
+	.refine(
+		input =>
+			!input.start_date ||
+			!input.end_date ||
+			input.start_date <= input.end_date,
+		{
+			message: 'start_date doit être antérieure ou égale à end_date',
+			path: ['end_date']
+		}
+	);
+
+const answerSchema = z.object({
+	field_code: z.string(),
+	field_label: z.string(),
+	answer_text: z.string(),
+	answer_item_id: z.number().int(),
+	intention: z.string().nullable(),
+	kind: z.string(),
+	parent_answer_id: z.number().int().nullable(),
+	parent: z
+		.object({
+			field_code: z.string(),
+			answer_text: z.string()
+		})
+		.nullable()
+});
+
+const reviewSchema = z.object({
+	id: z.number().int(),
+	created_at: z.string(),
+	form_id: z.number().int(),
+	product_id: z.number().int(),
+	button_id: z.number().int(),
+	form_template_slug: z.string(),
+	xwiki_id: z.number().int().nullable(),
+	has_verbatim: z.boolean(),
+	answers: z.array(answerSchema).optional()
+});
+
+export const reviewsListOutputSchema = z.object({
+	data: z.array(reviewSchema),
+	metadata: z.object({
+		next_cursor: z.string().nullable(),
+		has_more: z.boolean(),
+		limit: z.number().int()
+	})
+});
+
+const baseSelect: Prisma.ReviewSelect = {
+	id: true,
+	created_at: true,
+	form_id: true,
+	product_id: true,
+	button_id: true,
+	xwiki_id: true,
+	has_verbatim: true
+};
+
+const selectWithAnswers: Prisma.ReviewSelect = {
+	...baseSelect,
+	answers: {
+		select: {
+			field_code: true,
+			field_label: true,
+			answer_text: true,
+			answer_item_id: true,
+			intention: true,
+			kind: true,
+			parent_answer_id: true,
+			parent_answer: { select: { field_code: true, answer_text: true } }
+		}
+	}
+};
+
+type ReviewRow = {
+	id: number;
+	created_at: Date;
+	form_id: number;
+	product_id: number;
+	button_id: number;
+	xwiki_id: number | null;
+	has_verbatim: boolean;
+	answers?: Array<{
+		field_code: string;
+		field_label: string;
+		answer_text: string;
+		answer_item_id: number;
+		intention: string | null;
+		kind: string;
+		parent_answer_id: number | null;
+		parent_answer: { field_code: string; answer_text: string } | null;
+	}>;
+};
+
+export const reviewsListQuery = async ({
+	ctx,
+	input
+}: {
+	ctx: Context;
+	input: z.infer<typeof reviewsListInputSchema>;
+}) => {
+	const {
+		form_id,
+		product_id,
+		start_date,
+		end_date,
+		cursor,
+		limit,
+		include_answers
+	} = input;
+
+	const isAdmin = ctx.api_key?.scope.includes('admin') ?? false;
+	const authorized_products_ids = await getAuthorizedProductIds(ctx);
+
+	const notFound = () =>
+		new TRPCError({
+			code: 'NOT_FOUND',
+			message: 'Formulaire introuvable ou inaccessible'
+		});
+
+	const form = await ctx.prisma.form.findUnique({
+		where: { id: form_id },
+		include: { form_template: { select: { slug: true } } }
+	});
+
+	if (
+		!form ||
+		form.deleted_at !== null ||
+		form.isDeleted === true ||
+		(!isAdmin && !authorized_products_ids.includes(form.product_id)) ||
+		(!isAdmin && form.legacy && LEGACY_FORM_IDS.includes(form_id))
+	) {
+		throw notFound();
+	}
+
+	if (product_id !== undefined && product_id !== form.product_id) {
+		throw new TRPCError({
+			code: 'BAD_REQUEST',
+			message: 'product_id incohérent avec form_id'
+		});
+	}
+
+	const where: Prisma.ReviewWhereInput = {
+		product_id: form.product_id,
+		form_id: form.legacy
+			? { in: Array.from(new Set([...LEGACY_FORM_IDS, form_id])) }
+			: form_id
+	};
+
+	if (start_date || end_date) {
+		where.created_at = getDateWhereFromUTCRange(start_date, end_date);
+	}
+
+	if (cursor) {
+		const decoded = decodeCursor(cursor);
+		if (!decoded) {
+			throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cursor invalide' });
+		}
+		const ts = new Date(decoded.ts);
+		where.OR = [
+			{ created_at: { lt: ts } },
+			{ created_at: ts, id: { lt: decoded.id } }
+		];
+	}
+
+	const rows = (await ctx.prisma.review.findMany({
+		where,
+		orderBy: [{ created_at: 'desc' }, { id: 'desc' }],
+		take: limit + 1,
+		select: include_answers ? selectWithAnswers : baseSelect
+	})) as unknown as ReviewRow[];
+
+	const has_more = rows.length > limit;
+	const page = has_more ? rows.slice(0, limit) : rows;
+	const last = page[page.length - 1];
+	const next_cursor =
+		has_more && last
+			? encodeCursor({ ts: last.created_at.toISOString(), id: last.id })
+			: null;
+
+	await ctx.prisma.apiKeyLog.create({
+		data: {
+			apikey_id: ctx.api_key?.id ?? 0,
+			url: ctx.req.url ?? ''
+		}
+	});
+
+	const data = page.map(r => {
+		const base = {
+			id: r.id,
+			created_at: r.created_at.toISOString(),
+			form_id: r.form_id,
+			product_id: r.product_id,
+			button_id: r.button_id,
+			form_template_slug: form.form_template.slug,
+			xwiki_id: r.xwiki_id ?? null,
+			has_verbatim: r.has_verbatim
+		};
+		if (!r.answers) return base;
+		return {
+			...base,
+			answers: r.answers.map(a => ({
+				field_code: a.field_code,
+				field_label: a.field_label,
+				answer_text: a.answer_text,
+				answer_item_id: a.answer_item_id,
+				intention: a.intention,
+				kind: a.kind,
+				parent_answer_id: a.parent_answer_id,
+				parent: a.parent_answer
+					? {
+							field_code: a.parent_answer.field_code,
+							answer_text: a.parent_answer.answer_text
+					  }
+					: null
+			}))
+		};
+	});
+
+	return { data, metadata: { next_cursor, has_more, limit } };
+};

--- a/webapp-backoffice/src/server/routers/open-api/stats-usagers.ts
+++ b/webapp-backoffice/src/server/routers/open-api/stats-usagers.ts
@@ -11,6 +11,7 @@ import {
 	FetchAndFormatDataProps
 } from '@/src/utils/stats/index';
 import type { Context } from '@/src/server/trpc';
+import { getAuthorizedProductIds } from './utils';
 
 const MAX_NB_PRODUCTS = 10;
 
@@ -31,26 +32,7 @@ export const statsUsagersQuery = async ({
 	const { field_codes, product_ids, form_ids, start_date, end_date, interval } =
 		input;
 
-	const getAuthorizedProductIds = async (): Promise<number[]> => {
-		if (ctx.api_key?.product_id) {
-			return [ctx.api_key.product_id];
-		}
-
-		if (ctx.api_key?.entity_id) {
-			const entity = await ctx.prisma.entity.findFirst({
-				where: { id: ctx.api_key.entity_id },
-				include: { products: true }
-			});
-
-			if (entity && entity.products) {
-				return entity.products.map(prod => prod.id);
-			}
-		}
-
-		return [];
-	};
-
-	const authorized_products_ids: number[] = await getAuthorizedProductIds();
+	const authorized_products_ids: number[] = await getAuthorizedProductIds(ctx);
 
 	if (product_ids.length > 0) {
 		const existingProducts = await ctx.prisma.product.findMany({

--- a/webapp-backoffice/src/server/routers/open-api/utils.ts
+++ b/webapp-backoffice/src/server/routers/open-api/utils.ts
@@ -1,0 +1,22 @@
+import type { Context } from '@/src/server/trpc';
+
+export const getAuthorizedProductIds = async (
+	ctx: Context
+): Promise<number[]> => {
+	if (ctx.api_key?.product_id) {
+		return [ctx.api_key.product_id];
+	}
+
+	if (ctx.api_key?.entity_id) {
+		const entity = await ctx.prisma.entity.findFirst({
+			where: { id: ctx.api_key.entity_id },
+			include: { products: { select: { id: true } } }
+		});
+
+		if (entity?.products) {
+			return entity.products.map(p => p.id);
+		}
+	}
+
+	return [];
+};

--- a/webapp-backoffice/src/server/routers/open-api/utils.ts
+++ b/webapp-backoffice/src/server/routers/open-api/utils.ts
@@ -1,5 +1,7 @@
 import type { Context } from '@/src/server/trpc';
 
+export const LEGACY_FORM_IDS: readonly number[] = [1, 2];
+
 export const getAuthorizedProductIds = async (
 	ctx: Context
 ): Promise<number[]> => {
@@ -19,4 +21,29 @@ export const getAuthorizedProductIds = async (
 	}
 
 	return [];
+};
+
+export type ReviewCursor = { ts: string; id: number };
+
+export const encodeCursor = (cursor: ReviewCursor): string =>
+	Buffer.from(JSON.stringify(cursor), 'utf-8').toString('base64url');
+
+export const decodeCursor = (raw: string): ReviewCursor | null => {
+	try {
+		const parsed = JSON.parse(
+			Buffer.from(raw, 'base64url').toString('utf-8')
+		) as unknown;
+		if (
+			typeof parsed !== 'object' ||
+			parsed === null ||
+			typeof (parsed as ReviewCursor).ts !== 'string' ||
+			typeof (parsed as ReviewCursor).id !== 'number' ||
+			Number.isNaN(Date.parse((parsed as ReviewCursor).ts))
+		) {
+			return null;
+		}
+		return parsed as ReviewCursor;
+	} catch {
+		return null;
+	}
 };


### PR DESCRIPTION
Bonjour ! 

Je suis le dev en charge de https://demat.social.gouv.fr et nous venons d'intégrer votre outil. Dans le cadre de nos process on aimerait bien avoir une API pour récupérer les avis de nos questionnaires.

Je propose une petite PR pour ça :) Au plaisir d'échanger ! Je suis sur le mattermost SPDC ou sur teams : thibaut.poullain@externes.sg.social.gouv.fr

Merci !

## Contexte

L'API publique partenaires (`/api/open-api/*`) expose des stats agrégées
mais pas les avis bruts. Cette PR ajoute `GET /api/open-api/reviews` pour
qu'un partenaire muni d'une `ApiKey` puisse récupérer ses avis ligne à
ligne, pour les deux templates en place : avis classiques (`root`) et
remontées d'information (`bug`). Les deux types s'écrivent dans la même
table `Review`, le `form_template_slug` est ajouté à la réponse pour que
le client distingue.

## Endpoint

`GET /api/open-api/reviews?form_id=…`

| Param             | Type     | Détail                                                              |
|-------------------|----------|---------------------------------------------------------------------|
| `form_id`         | int      | obligatoire                                                         |
| `product_id`      | int?     | cross-check avec `form.product_id`                                  |
| `start_date`      | string?  | `YYYY-MM-DD`                                                        |
| `end_date`        | string?  | `YYYY-MM-DD`, doit être ≥ `start_date`                              |
| `cursor`          | string?  | opaque base64url de `{ts,id}`                                       |
| `limit`           | int      | défaut 50, max 100                                                  |
| `include_answers` | bool     | défaut `true`                                                       |

Pagination par cursor `(created_at desc, id desc)`, métadonnées
`{ next_cursor, has_more, limit }`.

## Sécurité

- **Anti-énumération** : `NOT_FOUND` unifié pour « form absent » et
  « form hors scope ApiKey » ; pas d'oracle 404 vs 403.
- **Anti-leak inter-tenants** : le `where` épingle toujours
  `product_id = form.product_id`, indispensable quand on étend la
  requête aux ids legacy historiques (`[1, 2]`).
- **Garde legacy** : un partenaire non-admin ne peut pas requêter
  `form_id=1` ou `form_id=2` directement si la `Form` correspondante
  est marquée `legacy=true` (cas prod). Sur une `Form` normale avec
  id 1 ou 2 (fresh install), la requête passe.
- **Cursor IDOR-safe** : le filtre `created_at` reste appliqué en
  cumul avec le cursor, un cursor forgé pointant hors fenêtre ne peut
  pas élargir la plage demandée.
- **Whitelist Prisma \`select\`** : un nouveau champ \`Review\` ou
  \`Answer\` ne fuite pas dans le contrat partenaire sans décision.

## Perf

- Nouvel index \`Review(form_id, created_at, id)\` propagé sur les
  150 partitions mensuelles de \`Review\` par Postgres (l'index existait
  déjà dans \`webapp-form/prisma/schema.prisma\`, cette PR aligne
  \`webapp-backoffice\`).
- \`EXPLAIN ANALYZE\` local confirme un \`Index Scan Backward\` sub-ms
  par partition.
- Recommandation à transmettre aux partenaires : passer
  \`start_date\`/\`end_date\` pour bénéficier du partition pruning.

## DRY

\`getAuthorizedProductIds\` était dupliqué dans \`info-services.ts\` et
\`stats-usagers.ts\`, extraction dans \`open-api/utils.ts\` (règle de
trois respectée avec le nouveau caller).

## Tests

15 scénarios Cypress (\`reviews-list.cy.ts\`), tous verts en local :

- doc OpenAPI exposée + auth (401 sans clé, 401 clé invalide)
- happy path \`bug\` avec \`answers\`
- toggle \`include_answers=false\`
- pagination cursor stable + cursor cassé 400 + cursor forgé sans
  effet sur la fenêtre date
- 404 anti-énumération cross-tenant, form inconnu, legacy ids 1/2
- 400 \`product_id\` incohérent, date malformée, plage inversée
- 404 form \`deleted_at\`/\`isDeleted\`

Wiring CI : le spec est importé dans \`cypress/e2e/jdma/launcher.cy.ts\`
parce que le workflow GHA ne cible que ce fichier launcher (\`tests.yml\`
ne fait pas de glob sur \`cypress/e2e/jdma/\`).

Le plugin Cypress \`cypress/plugins/db-tasks.ts\` introduit des tasks
\`db:setupApiCtx\`/\`db:seedReviews\`/\`db:cleanupApiCtx\` qui parlent
directement à Prisma : pas de soumission UI lente/fragile, fixtures
isolées par spec.

## Limites assumées (hors scope)

- **Rate limiting** absent côté backoffice de manière transversale.
  À monitorer via \`ApiKeyLog\` + protection WAF/CDN avant ouverture à
  un partenaire à fort volume.
- **\`ReviewCustom\`/\`AnswerCustom\`** sont des coquilles vides (aucune
  écriture en prod, seul un \`getList\` lit). Dette schéma à traiter
  séparément.
- **CGU partenaires sur verbatim + \`contact_email\`** : non bloquant
  code, à confirmer avant ouverture commerciale.

## Plan de déploiement

1. \`git pull && cd webapp-backoffice\`
2. \`npx prisma migrate deploy\` (ajoute l'index sur la table partitionnée).
   Sur volume Review très important, envisager un \`CREATE INDEX
   CONCURRENTLY\` par partition à la main pour éviter le lock écriture.
3. \`npx prisma generate\` côté \`webapp-backoffice\` et \`webapp-form\`.
4. Déploiement standard du backoffice.
5. Provisionner les \`ApiKey\` partenaires (scoped product ou entity).

## Vérif côté reviewer

- Recette curl rapide une fois déployé en staging :
  \`\`\`bash
  curl -H "Authorization: Bearer <KEY>" \\
    "https://<staging>/api/open-api/reviews?form_id=<ID>&limit=5" | jq
  \`\`\`
- Vérifier que la doc OpenAPI liste bien \`/reviews\` :
  \`curl https://<staging>/api/open-api | jq '.paths."/reviews"'\`